### PR TITLE
us-gov-east-1 Support

### DIFF
--- a/templates/application.template
+++ b/templates/application.template
@@ -186,15 +186,14 @@ Mappings:
       ELB: '033677994240'
     us-gov-west-1:
       ELB: '048591011584'
+    us-gov-east-1:
+      ELB: '190560391635'
     us-west-1:
       ELB: '027434742980'
     us-west-2:
       ELB: '797873946194'
 Conditions:
-  GovCloudCondition:
-    !Equals
-    - !Ref AWS::Region
-    - us-gov-west-1
+GovCloudCondition: !Or [!Equals [!Ref "AWS::Region", us-gov-west-1], !Equals [!Ref "AWS::Region", us-gov-east-1]]
   SupportsGlacier:
     !Equals
     - !Ref pSupportsGlacier

--- a/templates/main.template
+++ b/templates/main.template
@@ -168,6 +168,10 @@ Mappings:
       ConfigRules: 'true'
       NatGateway: 'true'
       Glacier: 'true'
+    us-gov-east-1:
+      ConfigRules: 'true'
+      NatGateway: 'true'
+      Glacier: 'true'
     us-west-1:
       ConfigRules: 'true'
       NatGateway: 'true'
@@ -228,9 +232,13 @@ Mappings:
       InstanceType: m4.large
       InstanceTypeDatabase: db.m4.large
     us-gov-west-1:
-      AMZNLINUXHVM: ami-ffa61d9e
-      InstanceType: m4.large
-      InstanceTypeDatabase: db.m3.large
+      AMZNLINUXHVM: ami-6cfab40d
+      InstanceType: m5.large
+      InstanceTypeDatabase: db.m5.large
+    us-gov-east-1:
+      AMZNLINUXHVM: ami-28ed0d59
+      InstanceType: m5.large
+      InstanceTypeDatabase: db.m5.large
     us-west-1:
       AMZNLINUXHVM: ami-0bce08e823ed38bdd
       InstanceType: m4.large
@@ -240,10 +248,15 @@ Mappings:
       InstanceType: m4.large
       InstanceTypeDatabase: db.m4.large
 Conditions:
-  GovCloudCondition:
+  GovCloudWest:
     !Equals
     - !Ref AWS::Region
     - us-gov-west-1
+  GovCloudEast:
+    !Equals
+    - !Ref AWS::Region
+    - us-gov-east-1
+  GovCloudCondition: !Or [!Equals [!Ref "AWS::Region", us-gov-west-1], !Equals [!Ref "AWS::Region", us-gov-east-1]]
   LoadConfigRulesTemplate:
     !Equals
     - !Ref pSupportsConfig


### PR DESCRIPTION
*Issue #, if available:* `us-gov-east-1` was not supported.

*Description of changes:*
- Modified the `GovCloudCondition` to check `!Or [!Equals [!Ref "AWS::Region", us-gov-west-1], !Equals [!Ref "AWS::Region", us-gov-east-1]]`
- Added `us-gov-east-1` to the `AWSAMIRegionMap`
- Updated `us-gov-east-1` and `us-gov-west-1` to the latest AL2 AMI

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
